### PR TITLE
Adding virtual destructor to PatternDetector

### DIFF
--- a/include/PatternDetector.hpp
+++ b/include/PatternDetector.hpp
@@ -42,6 +42,8 @@ namespace vernier {
         /** Default constructor */
         PatternDetector();
 
+        virtual ~PatternDetector() = default;
+
         /** Initializes a pattern detector from a JSON file */
         void loadFromJSON(const std::string filename);
 


### PR DESCRIPTION
The factories hand out `PatternDetector*` pointing at derived detectors,  
but the base class had no virtual destructor,  
so deleting through a base pointer was undefined behaviour.  
Adds `virtual ~PatternDetector() = default`.