### PR TITLE
Making FourierTransform non-copyable to protect FFT plans

### DIFF
--- a/include/FourierTransform.hpp
+++ b/include/FourierTransform.hpp
@@ -57,6 +57,16 @@ namespace vernier {
          */
         FourierTransform(Eigen::ArrayXcd& array, int sign = FFTW_FORWARD);
 
+        /** Copying is disabled since the instance owns the FFT plans */
+        FourierTransform(const FourierTransform&) = delete;
+
+        FourierTransform& operator=(const FourierTransform&) = delete;
+
+        /** Moving transfers ownership of the FFT plans */
+        FourierTransform(FourierTransform&&) noexcept;
+
+        FourierTransform& operator=(FourierTransform&&) noexcept;
+
         ~FourierTransform();
 
         /** Resizes the FFT plans

--- a/src/FourierTransform.cpp
+++ b/src/FourierTransform.cpp
@@ -34,6 +34,32 @@ namespace vernier {
         }
     }
 
+    FourierTransform::FourierTransform(FourierTransform&& other) noexcept {
+        nRows = other.nRows;
+        nCols = other.nCols;
+        sign = other.sign;
+        plan = other.plan;
+        other.plan = NULL;
+        other.nRows = 0;
+        other.nCols = 0;
+    }
+
+    FourierTransform& FourierTransform::operator=(FourierTransform&& other) noexcept {
+        if (this != &other) {
+            if (plan != NULL) {
+                fftw_destroy_plan(plan);
+            }
+            nRows = other.nRows;
+            nCols = other.nCols;
+            sign = other.sign;
+            plan = other.plan;
+            other.plan = NULL;
+            other.nRows = 0;
+            other.nCols = 0;
+        }
+        return *this;
+    }
+
     void FourierTransform::resize(int nRows, int nCols, int sign) {
         if (nRows <= 0 || nCols <= 0) {
             throw Exception("Can't resize a FourierTransform with rows<=0 or cols<=0");
@@ -120,6 +146,53 @@ namespace vernier {
         if (cosSinTable != NULL) {
             free(cosSinTable);
         }
+    }
+
+    FourierTransform::FourierTransform(FourierTransform&& other) noexcept {
+        nRows = other.nRows;
+        nCols = other.nCols;
+        sign = other.sign;
+        data = other.data;
+        workArea = other.workArea;
+        bitReversal = other.bitReversal;
+        cosSinTable = other.cosSinTable;
+        other.data = NULL;
+        other.workArea = NULL;
+        other.bitReversal = NULL;
+        other.cosSinTable = NULL;
+        other.nRows = 0;
+        other.nCols = 0;
+    }
+
+    FourierTransform& FourierTransform::operator=(FourierTransform&& other) noexcept {
+        if (this != &other) {
+            if (data != NULL) {
+                free(data);
+            }
+            if (workArea != NULL) {
+                free(workArea);
+            }
+            if (bitReversal != NULL) {
+                free(bitReversal);
+            }
+            if (cosSinTable != NULL) {
+                free(cosSinTable);
+            }
+            nRows = other.nRows;
+            nCols = other.nCols;
+            sign = other.sign;
+            data = other.data;
+            workArea = other.workArea;
+            bitReversal = other.bitReversal;
+            cosSinTable = other.cosSinTable;
+            other.data = NULL;
+            other.workArea = NULL;
+            other.bitReversal = NULL;
+            other.cosSinTable = NULL;
+            other.nRows = 0;
+            other.nCols = 0;
+        }
+        return *this;
     }
 
     void FourierTransform::resize(int nRows, int nCols, int sign) {


### PR DESCRIPTION
`FourierTransform` owns a raw FFTW plan and frees it in its destructor,  
but had no copy constructor or assignment operator.  
Copying one (easy to do by accident, since it's held by value inside the detectors) would double-free the plan.  
Deletes the copy operations so the mistake becomes a compile error instead of a crash.
Adds move operations to make sure the assignment still works in the tests and later uses