### PR TITLE
Detector and Layout factories returning unique pointers

### DIFF
--- a/include/Detector.hpp
+++ b/include/Detector.hpp
@@ -13,6 +13,7 @@
 #include "BitmapPatternDetector.hpp"
 #include "HPCodePatternDetector.hpp"
 #include "StampPatternDetector.hpp"
+#include <memory>
 
 namespace vernier {
 
@@ -27,18 +28,18 @@ namespace vernier {
          *   
          *   \param classname: name of the pattern detector (PeriodicPattern, MegarenaPattern, BitmapPattern, HPCodePattern).
          **/
-        static PatternDetector* newInstance(const std::string& classname) {
-            PatternDetector* detector;
+        static std::unique_ptr<PatternDetector> newInstance(const std::string& classname) {
+            std::unique_ptr<PatternDetector> detector;
             if (classname == "PeriodicPattern") {
-                detector = new PeriodicPatternDetector();
+                detector.reset(new PeriodicPatternDetector());
             } else if (classname == "MegarenaPattern") {
-                detector = new MegarenaPatternDetector();
+                detector.reset(new MegarenaPatternDetector());
             } else if (classname == "BitmapPattern") {
-                detector = new BitmapPatternDetector();
+                detector.reset(new BitmapPatternDetector());
             } else if (classname == "HPCodePattern") {
-                detector = new HPCodePatternDetector();
+                detector.reset(new HPCodePatternDetector());
             } else if (classname == "StampPattern") {
-                detector = new StampPatternDetector();
+                detector.reset(new StampPatternDetector());
             } else {
                 throw Exception(classname + " is not a valid class name for a pattern detector.");
             }
@@ -49,7 +50,7 @@ namespace vernier {
          *
          *   \param filename: name of the JSON document to load
          **/
-        static PatternDetector * loadFromJSON(const std::string& filename) {
+        static std::unique_ptr<PatternDetector> loadFromJSON(const std::string& filename) {
             BufferedReader bufferedReader(filename);
             rapidjson::Document document;
             document.ParseInsitu(bufferedReader.data());
@@ -60,7 +61,7 @@ namespace vernier {
                 throw Exception(filename + " is empty.");
             }
             std::string classname = document.MemberBegin()->name.GetString();
-            PatternDetector* detector = newInstance(classname);
+            std::unique_ptr<PatternDetector> detector = newInstance(classname);
             detector->readJSON(document.MemberBegin()->value);
             return detector;
         }

--- a/include/Layout.hpp
+++ b/include/Layout.hpp
@@ -14,33 +14,34 @@
 #include "MegarenaPatternLayout.hpp"
 #include "HPCodePatternLayout.hpp"
 #include "CustomPatternLayout.hpp"
+#include <memory>
 
 namespace vernier {
 
     class Layout {
     public:
 
-        static PatternLayout * newInstance(const std::string& classname) {
-            PatternLayout* layout;
+        static std::unique_ptr<PatternLayout> newInstance(const std::string& classname) {
+            std::unique_ptr<PatternLayout> layout;
             if (classname == "PeriodicPattern") {
-                layout = new PeriodicPatternLayout();
+                layout.reset(new PeriodicPatternLayout());
             } else if (classname == "BitmapPattern") {
-                layout = new BitmapPatternLayout();
+                layout.reset(new BitmapPatternLayout());
             } else if (classname == "FingerprintPattern") {
-                layout = new FingerprintPatternLayout();
+                layout.reset(new FingerprintPatternLayout());
             } else if (classname == "MegarenaPattern") {
-                layout = new MegarenaPatternLayout();
+                layout.reset(new MegarenaPatternLayout());
             } else if (classname == "HPCodePattern") {
-                layout = new HPCodePatternLayout();
+                layout.reset(new HPCodePatternLayout());
             } else if (classname == "CustomPattern") {
-                layout = new CustomPatternLayout();
+                layout.reset(new CustomPatternLayout());
             } else {
                 throw Exception(classname + " is not a valid class name for a pattern layout.");
             }
             return layout;
         }
 
-        static PatternLayout * loadFromJSON(const std::string& filename) {
+        static std::unique_ptr<PatternLayout> loadFromJSON(const std::string& filename) {
             BufferedReader bufferedReader(filename);
             rapidjson::Document document;
             document.ParseInsitu(bufferedReader.data());
@@ -51,7 +52,7 @@ namespace vernier {
                 throw Exception(filename + " is empty.");
             }
             std::string classname = document.MemberBegin()->name.GetString();
-            PatternLayout* layout = newInstance(classname);
+            std::unique_ptr<PatternLayout> layout = newInstance(classname);
             layout->readJSON(document.MemberBegin()->value);
             return layout;
         }

--- a/include/PatternDetector.hpp
+++ b/include/PatternDetector.hpp
@@ -42,6 +42,8 @@ namespace vernier {
         /** Default constructor */
         PatternDetector();
 
+        virtual ~PatternDetector() = default;
+
         /** Initializes a pattern detector from a JSON file */
         void loadFromJSON(const std::string filename);
 

--- a/test/TestMegarenaPatternDetector.cpp
+++ b/test/TestMegarenaPatternDetector.cpp
@@ -139,8 +139,7 @@ int exampleCapture() {
     imshow("Camera", frame);
 
     // Detecting and estimating the pose of the pattern
-    PatternDetector* detector;
-    detector = Detector::loadFromJSON("megarenaPattern.json");
+    std::unique_ptr<PatternDetector> detector = Detector::loadFromJSON("megarenaPattern.json");
     detector->compute(frame);
 
     // Printing results 

--- a/test/TestPatternLayout.cpp
+++ b/test/TestPatternLayout.cpp
@@ -12,11 +12,9 @@ using namespace vernier;
 using namespace std;
 
 void main0() {
-    PatternLayout *layout;
-    layout = Layout::loadFromJSON("testQRCodePattern.json");
+    std::unique_ptr<PatternLayout> layout = Layout::loadFromJSON("testQRCodePattern.json");
     layout->saveToSVG();
     std::cout << "Genération terminée" << std::endl;
-    delete layout;
 }
 
 void main1() {

--- a/test/testBitmapPatternDetector.cpp
+++ b/test/testBitmapPatternDetector.cpp
@@ -39,8 +39,7 @@ void main2() {
     //    BitmapPatternLayout layout5("data/HPCode33x33.png", 2);
     //    layout5.saveToJSON("BitmapPatternDetector.json");
 
-    PatternDetector* detector;
-    detector = Detector::loadFromJSON("BitmapPatternDetector.json");
+    std::unique_ptr<PatternDetector> detector = Detector::loadFromJSON("BitmapPatternDetector.json");
     cout << detector->toString() << endl;
 
     cv::Mat image = cv::imread("data/QRCode/code18.jpg");


### PR DESCRIPTION
`Detector::loadFromJSON` / `newInstance` (and the `Layout` equivalents) returned raw owning pointers,  
leaving callers to remember to `delete`.  
They now return `std::unique_ptr`.  
Callers in the tests and examples are updated.

Depends on #8 