### PR TITLE
Render dedup

### DIFF
--- a/src/PatternLayout.cpp
+++ b/src/PatternLayout.cpp
@@ -318,6 +318,94 @@ namespace vernier {
         file.close();
     }
 
+    // Checks that the output image has positive and even dimensions and returns
+    // the principal point, defaulting to the image center.
+    static Eigen::Vector2d checkSizeAndPrincipalPoint(int rows, int cols, Eigen::Vector2d principalPoint) {
+        if (rows <= 0 || rows % 2 == 1) {
+            throw Exception("The number of rows must be positive and even.");
+        }
+        if (cols <= 0 || cols % 2 == 1) {
+            throw Exception("The number of columns must be positive and even.");
+        }
+        if (principalPoint(0) < 0) {
+            principalPoint(0) = cols / 2.0;
+            principalPoint(1) = rows / 2.0;
+        }
+        return principalPoint;
+    }
+
+    // Returns the inverse of the homography mapping the pattern plane to the image
+    static Eigen::Matrix3d computeInversedHomography(Pose & pose, const Eigen::MatrixXd & cameraMatrix) {
+        Eigen::Matrix4d cTp = pose.getCameraToPatternTransformationMatrix();
+
+        Eigen::MatrixXd M(4, 3);
+        M << 1.0, 0.0, 0.0,
+                0.0, 1.0, 0.0,
+                0.0, 0.0, 0.0,
+                0.0, 0.0, 1.0;
+
+        Eigen::Matrix3d homography = cameraMatrix * cTp * M;
+        return homography.inverse();
+    }
+
+    // Back-projection from the image to the pattern plane using the unified
+    // omnidirectional camera model (UCM)
+    class UCMBackProjection {
+    public:
+
+        UCMBackProjection(Pose & pose, double focalLength, double xi, const Eigen::Vector2d & principalPoint) : xi(xi) {
+            Eigen::MatrixXd cameraMatrix(3, 3);
+            cameraMatrix << focalLength, 0.0, principalPoint(0),
+                    0.0, focalLength, principalPoint(1),
+                    0.0, 0.0, 1.0;
+            inverseCameraMatrix = cameraMatrix.inverse();
+
+            Eigen::Matrix4d cTp = pose.getCameraToPatternTransformationMatrix();
+            inverseTransform = cTp.inverse();
+
+            xiVector = Eigen::Vector3d(0.0, 0.0, xi);
+            planPose = Eigen::Vector3d(pose.x, pose.y, pose.z - xi);
+            planNormal = (inverseTransform * Eigen::Vector4d(0.0, 0.0, 1.0, 0.0)).head<3>().normalized();
+        }
+
+        // Returns false when the image point is projected behind the camera
+        bool backProject(int row, int col, double & x, double & y) const {
+            // Projection of Xi (homogeneous coordinates of the 2D point in the sensor plane) to
+            // Xpi (normalized image frame) using the inverse of the intrinsic matrix
+            Eigen::Vector3d pointImage(col, row, 1);
+            Eigen::Vector3d pointCamera = inverseCameraMatrix * pointImage;
+
+            // Projection of Xpi (normalized image frame) to Xs (surface of the sphere) using
+            // the inverse of the omnidirectional distortion model
+            double sommeCarres = pointCamera.norm() - 1;
+            double lambda1 = (xi + sqrt(1 + (1 - xi * xi) * sommeCarres)) / (sommeCarres + 1);
+            Eigen::Vector3d pointSphere = pointCamera * lambda1;
+
+            // Projection of Xs (surface of the sphere) to Xp (object plane) using the
+            // intersection of the ray defined by Xs and the plane defined by the pattern (Z=0)
+            double lambda2 = planNormal.dot(planPose) / planNormal.dot(pointSphere - xiVector);
+
+            // A negative lambda2 value means that the point is projected behind the camera
+            if (lambda2 <= 0) {
+                return false;
+            }
+            Eigen::Vector3d pointPattern = (pointSphere * lambda2) + xiVector * (1 - lambda2);
+            Eigen::Vector4d pointPatternHomogeneous = inverseTransform * pointPattern.homogeneous();
+            x = pointPatternHomogeneous.x();
+            y = pointPatternHomogeneous.y();
+            return true;
+        }
+
+    private:
+
+        Eigen::Matrix3d inverseCameraMatrix;
+        Eigen::Matrix4d inverseTransform;
+        Eigen::Vector3d xiVector;
+        Eigen::Vector3d planPose;
+        Eigen::Vector3d planNormal;
+        double xi;
+    };
+
     void PatternLayout::renderOrthographicProjection(Pose pose, cv::Mat & outputImage) {
         renderOrthographicProjection(pose, outputImage, 1.0 / pose.pixelSize);
     }
@@ -333,33 +421,14 @@ namespace vernier {
     }
 
     void PatternLayout::renderOrthographicProjection(Pose pose, Eigen::ArrayXXd & outputImage, double scale, Eigen::Vector2d principalPoint) {
-        if (outputImage.rows() <= 0 || outputImage.rows() % 2 == 1) {
-            throw Exception("The number of rows must be positive and even.");
-        }
-        if (outputImage.cols() <= 0 || outputImage.cols() % 2 == 1) {
-            throw Exception("The number of columns must be positive and even.");
-        }
-
-        if (principalPoint(0) < 0) {
-            principalPoint(0) = outputImage.cols() / 2.0;
-            principalPoint(1) = outputImage.rows() / 2.0;
-        }
+        principalPoint = checkSizeAndPrincipalPoint(outputImage.rows(), outputImage.cols(), principalPoint);
 
         Eigen::MatrixXd cameraMatrix(3, 4);
         cameraMatrix << scale, 0.0, 0.0, principalPoint(0),
                 0.0, scale, 0.0, principalPoint(1),
                 0.0, 0.0, 0.0, 1;
 
-        Eigen::Matrix4d cTp = pose.getCameraToPatternTransformationMatrix();
-
-        Eigen::MatrixXd M(4, 3);
-        M << 1.0, 0.0, 0.0,
-                0.0, 1.0, 0.0,
-                0.0, 0.0, 0.0,
-                0.0, 0.0, 1.0;
-
-        Eigen::Matrix3d homography = cameraMatrix * cTp * M;
-        Eigen::Matrix3d inversedHomography = homography.inverse();
+        Eigen::Matrix3d inversedHomography = computeInversedHomography(pose, cameraMatrix);
 
         for (int col = 0; col < outputImage.cols(); col++) {
             for (int row = 0; row < outputImage.rows(); row++) {
@@ -377,33 +446,14 @@ namespace vernier {
     }
 
     void PatternLayout::renderPerspectiveProjection(Pose pose, Eigen::ArrayXXd & outputImage, double focalLength, Eigen::Vector2d principalPoint) {
-        if (outputImage.rows() <= 0 || outputImage.rows() % 2 == 1) {
-            throw Exception("The number of rows must be positive and even.");
-        }
-        if (outputImage.cols() <= 0 || outputImage.cols() % 2 == 1) {
-            throw Exception("The number of columns must be positive and even.");
-        }
-
-        if (principalPoint(0) < 0) {
-            principalPoint(0) = outputImage.cols() / 2.0;
-            principalPoint(1) = outputImage.rows() / 2.0;
-        }
+        principalPoint = checkSizeAndPrincipalPoint(outputImage.rows(), outputImage.cols(), principalPoint);
 
         Eigen::MatrixXd cameraMatrix(3, 4);
         cameraMatrix << focalLength, 0.0, principalPoint(0), 0.0,
                 0.0, focalLength, principalPoint(1), 0.0,
                 0.0, 0.0, 1.0, 0.0;
 
-        Eigen::Matrix4d cTp = pose.getCameraToPatternTransformationMatrix();
-
-        Eigen::MatrixXd M(4, 3);
-        M << 1.0, 0.0, 0.0,
-                0.0, 1.0, 0.0,
-                0.0, 0.0, 0.0,
-                0.0, 0.0, 1.0;
-
-        Eigen::Matrix3d homography = cameraMatrix * cTp * M;
-        Eigen::Matrix3d inversedHomography = homography.inverse();
+        Eigen::Matrix3d inversedHomography = computeInversedHomography(pose, cameraMatrix);
 
         for (int col = 0; col < outputImage.cols(); col++) {
             for (int row = 0; row < outputImage.rows(); row++) {
@@ -422,60 +472,21 @@ namespace vernier {
     }
 
     void PatternLayout::renderUCMProjection(Pose pose, Eigen::ArrayXXd & outputImage, double focalLength, double xi, Eigen::Vector2d principalPoint) {
-        if (outputImage.rows() <= 0 || outputImage.rows() % 2 == 1) {
-            throw Exception("The number of rows must be positive and even.");
-        }
-        if (outputImage.cols() <= 0 || outputImage.cols() % 2 == 1) {
-            throw Exception("The number of columns must be positive and even.");
-        }
+        principalPoint = checkSizeAndPrincipalPoint(outputImage.rows(), outputImage.cols(), principalPoint);
 
-        if (principalPoint(0) < 0) {
-            principalPoint(0) = outputImage.cols() / 2.0;
-            principalPoint(1) = outputImage.rows() / 2.0;
-        }
-
-        Eigen::MatrixXd cameraMatrix(3, 3);
-        cameraMatrix << focalLength, 0.0, principalPoint(0),
-                0.0, focalLength, principalPoint(1),
-                0.0, 0.0, 1.0;
-        Eigen::Matrix3d inverseCameraMatrix = cameraMatrix.inverse();
-
-        Eigen::Matrix4d cTp = pose.getCameraToPatternTransformationMatrix();
-        Eigen::Matrix4d inverseTransform = cTp.inverse();
-
-        Eigen::Vector3d xiVector(0.0, 0.0, xi);
-        Eigen::Vector3d planPose(pose.x, pose.y, pose.z - xi);
-        Eigen::Vector3d planNormal = (inverseTransform * Eigen::Vector4d(0.0, 0.0, 1.0, 0.0)).head<3>().normalized();
+        UCMBackProjection projection(pose, focalLength, xi, principalPoint);
 
         for (int col = 0; col < outputImage.cols(); col++) {
             for (int row = 0; row < outputImage.rows(); row++) {
-                // Projection of Xi (homogeneous coordinates of the 2D point in the sensor plane) to 
-                // Xpi (normalized image frame) using the inverse of the intrinsic matrix
-                Eigen::Vector3d pointImage(col, row, 1);
-                Eigen::Vector3d pointCamera = inverseCameraMatrix * pointImage;
-
-                // Projection of Xpi (normalized image frame) to Xs (surface of the sphere) using 
-                // the inverse of the omnidirectional distortion model
-                double sommeCarres = pointCamera.norm() - 1;
-                double lambda1 = (xi + sqrt(1 + (1 - xi * xi) * sommeCarres)) / (sommeCarres + 1);
-                Eigen::Vector3d pointSphere = pointCamera * lambda1;
-                
-                // Projection of Xs (surface of the sphere) to Xp (object plane) using the 
-                // intersection of the ray defined by Xs and the plane defined by the pattern (Z=0)
-                double lambda2 = planNormal.dot(planPose) / planNormal.dot(pointSphere - xiVector);
-                Eigen::Vector3d pointPattern = (pointSphere * lambda2) + xiVector * (1 - lambda2);
-
-                // Check if the calculated lambda2 value is negative, which means that the point 
-                // is projected behind the camera
-                if (lambda2 <= 0) {
-                    outputImage(row, col) = 0.0;
+                double x, y;
+                if (projection.backProject(row, col, x, y)) {
+                    outputImage(row, col) = this->getIntensity(x, y);
                 } else {
-                    Eigen::Vector4d pointPatternHomogeneous = inverseTransform * pointPattern.homogeneous();
-                    outputImage(row, col) = this->getIntensity(pointPatternHomogeneous.x(), pointPatternHomogeneous.y());
+                    outputImage(row, col) = 0.0;
                 }
             }
         }
-    }   
+    }
 
     void PatternLayout::renderPhaseImagesPerspectiveProjection(Pose pose, cv::Mat & outputPhase1, cv::Mat & outputPhase2, 
         double focalLength, Eigen::Vector2d principalPoint) {
@@ -487,38 +498,19 @@ namespace vernier {
         eigen2cv(arrayPhase2, outputPhase2);
     }
 
-    void PatternLayout::renderPhaseImagesPerspectiveProjection(Pose pose, Eigen::ArrayXXd & outputPhase1, Eigen::ArrayXXd & outputPhase2, 
+    void PatternLayout::renderPhaseImagesPerspectiveProjection(Pose pose, Eigen::ArrayXXd & outputPhase1, Eigen::ArrayXXd & outputPhase2,
         double focalLength, Eigen::Vector2d principalPoint) {
-        if (outputPhase1.rows() <= 0 || outputPhase1.rows() % 2 == 1) {
-            throw Exception("The number of rows must be positive and even.");
-        }
-        if (outputPhase1.cols() <= 0 || outputPhase1.cols() % 2 == 1) {
-            throw Exception("The number of columns must be positive and even.");
-        }
         if (outputPhase2.rows() != outputPhase1.rows() || outputPhase2.cols() != outputPhase1.cols()) {
             throw Exception("The dimensions of the two output images must be the same.");
         }
-
-        if (principalPoint(0) < 0) {
-            principalPoint(0) = outputPhase1.cols() / 2.0;
-            principalPoint(1) = outputPhase1.rows() / 2.0;
-        }
+        principalPoint = checkSizeAndPrincipalPoint(outputPhase1.rows(), outputPhase1.cols(), principalPoint);
 
         Eigen::MatrixXd cameraMatrix(3, 4);
         cameraMatrix << focalLength, 0.0, principalPoint(0), 0.0,
                 0.0, focalLength, principalPoint(1), 0.0,
                 0.0, 0.0, 1.0, 0.0;
 
-        Eigen::Matrix4d cTp = pose.getCameraToPatternTransformationMatrix();
-
-        Eigen::MatrixXd M(4, 3);
-        M << 1.0, 0.0, 0.0,
-                0.0, 1.0, 0.0,
-                0.0, 0.0, 0.0,
-                0.0, 0.0, 1.0;
-
-        Eigen::Matrix3d homography = cameraMatrix * cTp * M;
-        Eigen::Matrix3d inversedHomography = homography.inverse();
+        Eigen::Matrix3d inversedHomography = computeInversedHomography(pose, cameraMatrix);
 
         for (int col = 0; col < outputPhase1.cols(); col++) {
             for (int row = 0; row < outputPhase1.rows(); row++) {
@@ -543,61 +535,22 @@ namespace vernier {
 
     void PatternLayout::renderPhaseImagesUCMProjection(Pose pose, Eigen::ArrayXXd & outputPhase1, Eigen::ArrayXXd & outputPhase2,
         double focalLength, double xi, Eigen::Vector2d principalPoint) {
-        if (outputPhase1.rows() <= 0 || outputPhase1.rows() % 2 == 1) {
-            throw Exception("The number of rows must be positive and even.");
-        }
-        if (outputPhase1.cols() <= 0 || outputPhase1.cols() % 2 == 1) {
-            throw Exception("The number of columns must be positive and even.");
-        }
         if (outputPhase2.rows() != outputPhase1.rows() || outputPhase2.cols() != outputPhase1.cols()) {
             throw Exception("The dimensions of the two output images must be the same.");
         }
+        principalPoint = checkSizeAndPrincipalPoint(outputPhase1.rows(), outputPhase1.cols(), principalPoint);
 
-        if (principalPoint(0) < 0) {
-            principalPoint(0) = outputPhase1.cols() / 2.0;
-            principalPoint(1) = outputPhase1.rows() / 2.0;
-        }
-
-        Eigen::MatrixXd cameraMatrix(3, 3);
-        cameraMatrix << focalLength, 0.0, principalPoint(0),
-                0.0, focalLength, principalPoint(1),
-                0.0, 0.0, 1.0;
-        Eigen::Matrix3d inverseCameraMatrix = cameraMatrix.inverse();
-
-        Eigen::Matrix4d cTp = pose.getCameraToPatternTransformationMatrix();
-        Eigen::Matrix4d inverseTransform = cTp.inverse();
-
-        Eigen::Vector3d xiVector(0.0, 0.0, xi);
-        Eigen::Vector3d planPose(pose.x, pose.y, pose.z - xi);
-        Eigen::Vector3d planNormal = (inverseTransform * Eigen::Vector4d(0.0, 0.0, 1.0, 0.0)).head<3>().normalized();
+        UCMBackProjection projection(pose, focalLength, xi, principalPoint);
 
         for (int col = 0; col < outputPhase1.cols(); col++) {
             for (int row = 0; row < outputPhase1.rows(); row++) {
-                // Projection of Xi (homogeneous coordinates of the 2D point in the sensor plane) to 
-                // Xpi (normalized image frame) using the inverse of the intrinsic matrix
-                Eigen::Vector3d pointImage(col, row, 1);
-                Eigen::Vector3d pointCamera = inverseCameraMatrix * pointImage;
-
-                // Projection of Xpi (normalized image frame) to Xs (surface of the sphere) using 
-                // the inverse of the omnidirectional distortion model
-                double sommeCarres = pointCamera.norm() - 1;
-                double lambda1 = (xi + sqrt(1 + (1 - xi * xi) * sommeCarres)) / (sommeCarres + 1);
-                Eigen::Vector3d pointSphere = pointCamera * lambda1;
-                
-                // Projection of Xs (surface of the sphere) to Xp (object plane) using the 
-                // intersection of the ray defined by Xs and the plane defined by the pattern (Z=0)
-                double lambda2 = planNormal.dot(planPose) / planNormal.dot(pointSphere - xiVector);
-                Eigen::Vector3d pointPattern = (pointSphere * lambda2) + xiVector * (1 - lambda2);
-
-                // Check if the calculated lambda2 value is negative, which means that the point 
-                // is projected behind the camera
-                if (lambda2 <= 0) {
+                double x, y;
+                if (projection.backProject(row, col, x, y)) {
+                    outputPhase1(row, col) = this->getPhase1(x, y);
+                    outputPhase2(row, col) = this->getPhase2(x, y);
+                } else {
                     outputPhase1(row, col) = 0.0;
                     outputPhase2(row, col) = 0.0;
-                } else {
-                    Eigen::Vector4d pointPatternHomogeneous = inverseTransform * pointPattern.homogeneous();
-                    outputPhase1(row, col) = this->getPhase1(pointPatternHomogeneous.x(), pointPatternHomogeneous.y());
-                    outputPhase2(row, col) = this->getPhase2(pointPatternHomogeneous.x(), pointPatternHomogeneous.y());
                 }
             }
         }


### PR DESCRIPTION
The six render methods in `PatternLayout` each repeated the same size check,
homography setup and pixel loop, and the UCM ray-casting block was copy-pasted twice.
Pulls the common parts into three small helpers (`checkSizeAndPrincipalPoint`, `computeInversedHomography`, a `UCMBackProjection` class).
About 150 fewer lines.
