### PR TITLE
Factorizing JSON file parsing in BufferedReader

### DIFF
--- a/include/BufferedReader.hpp
+++ b/include/BufferedReader.hpp
@@ -16,6 +16,7 @@ namespace vernier {
     private:
         long length;
         char* buffer;
+        std::string filename;
 
     public:
 
@@ -51,6 +52,13 @@ namespace vernier {
          **/
         void release();
 
+
+        /** Parses the buffer as a JSON file and checks that it contains a root object
+         *
+         *   \param document: rapidjson document to fill (the document points into the
+         *   buffer and must not outlive the reader)
+         **/
+        void parseJSON(rapidjson::Document & document);
 
         /** Returns the buffer of the read file
          **/

--- a/include/Detector.hpp
+++ b/include/Detector.hpp
@@ -52,13 +52,7 @@ namespace vernier {
         static PatternDetector * loadFromJSON(const std::string& filename) {
             BufferedReader bufferedReader(filename);
             rapidjson::Document document;
-            document.ParseInsitu(bufferedReader.data());
-            if (!document.IsObject()) {
-                throw Exception(filename + " is not a valid JSON file.");
-            }
-            if (document.MemberBegin() == document.MemberEnd()) {
-                throw Exception(filename + " is empty.");
-            }
+            bufferedReader.parseJSON(document);
             std::string classname = document.MemberBegin()->name.GetString();
             PatternDetector* detector = newInstance(classname);
             detector->readJSON(document.MemberBegin()->value);

--- a/include/Layout.hpp
+++ b/include/Layout.hpp
@@ -43,13 +43,7 @@ namespace vernier {
         static PatternLayout * loadFromJSON(const std::string& filename) {
             BufferedReader bufferedReader(filename);
             rapidjson::Document document;
-            document.ParseInsitu(bufferedReader.data());
-            if (!document.IsObject()) {
-                throw Exception(filename + " is not a valid JSON file.");
-            }
-            if (document.MemberBegin() == document.MemberEnd()) {
-                throw Exception(filename + " is empty.");
-            }
+            bufferedReader.parseJSON(document);
             std::string classname = document.MemberBegin()->name.GetString();
             PatternLayout* layout = newInstance(classname);
             layout->readJSON(document.MemberBegin()->value);

--- a/src/BufferedReader.cpp
+++ b/src/BufferedReader.cpp
@@ -31,6 +31,7 @@ namespace vernier {
 
     void BufferedReader::load(const char * filename) {
         release();
+        this->filename = filename;
 
         FILE *file = fopen(filename, "r");
         if (file == NULL) {
@@ -59,6 +60,16 @@ namespace vernier {
             free(buffer);
             buffer = NULL;
             length = 0;
+        }
+    }
+
+    void BufferedReader::parseJSON(rapidjson::Document & document) {
+        document.ParseInsitu(buffer);
+        if (!document.IsObject()) {
+            throw Exception(filename + " is not a valid JSON file.");
+        }
+        if (document.MemberBegin() == document.MemberEnd()) {
+            throw Exception(filename + " is empty.");
         }
     }
 

--- a/src/PatternDetector.cpp
+++ b/src/PatternDetector.cpp
@@ -41,15 +41,8 @@ namespace vernier {
 
     void PatternDetector::loadFromJSON(const std::string filename) {
         BufferedReader bufferedReader(filename);
-
         rapidjson::Document document;
-        document.ParseInsitu(bufferedReader.data());
-        if (!document.IsObject()) {
-            throw Exception(filename + " is not a valid JSON file.");
-        }
-        if (document.MemberBegin() == document.MemberEnd()) {
-            throw Exception(filename + " is empty.");
-        }
+        bufferedReader.parseJSON(document);
         readJSON(document.MemberBegin()->value);
     }
 

--- a/src/PatternLayout.cpp
+++ b/src/PatternLayout.cpp
@@ -124,15 +124,8 @@ namespace vernier {
 
     void PatternLayout::loadFromJSON(const std::string & filename) {
         BufferedReader bufferedReader(filename);
-
         rapidjson::Document document;
-        document.ParseInsitu(bufferedReader.data());
-        if (!document.IsObject()) {
-            throw Exception(filename + " is not a valid JSON file.");
-        }
-        if (document.MemberBegin() == document.MemberEnd()) {
-            throw Exception(filename + " is empty.");
-        }
+        bufferedReader.parseJSON(document);
         readJSON(document.MemberBegin()->value);
     };
 


### PR DESCRIPTION
Move the "open, parse in place, check it's a non-empty object" boilerplate
(which was copy-pasted in four places) into `BufferedReader::parseJSON()`.