### PR TITLE
Removing GUI and calib3d includes from Common header

### DIFF
--- a/examples/analysingImage.cpp
+++ b/examples/analysingImage.cpp
@@ -1,4 +1,6 @@
 #include "Vernier.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace cv;

--- a/examples/detectingHPCodePattern.cpp
+++ b/examples/detectingHPCodePattern.cpp
@@ -1,4 +1,6 @@
 #include "Vernier.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace cv;

--- a/examples/detectingMegarenaPattern.cpp
+++ b/examples/detectingMegarenaPattern.cpp
@@ -1,4 +1,6 @@
 #include "Vernier.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace cv;

--- a/examples/detectingMegarenaPattern3D.cpp
+++ b/examples/detectingMegarenaPattern3D.cpp
@@ -1,4 +1,6 @@
 #include "Vernier.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace cv;

--- a/examples/detectingStampPattern.cpp
+++ b/examples/detectingStampPattern.cpp
@@ -1,4 +1,6 @@
 #include "Vernier.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace cv;

--- a/examples/renderingPatternImage.cpp
+++ b/examples/renderingPatternImage.cpp
@@ -1,4 +1,5 @@
 #include "Vernier.hpp"
+#include <opencv2/highgui/highgui.hpp>
 
 using namespace vernier;
 using namespace cv;

--- a/include/Common.hpp
+++ b/include/Common.hpp
@@ -29,9 +29,7 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/core/types.hpp>
 #include <opencv2/core/eigen.hpp>
-#include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/calib3d.hpp>
 
 #include <rapidjson/document.hpp>
 

--- a/src/BitmapPatternDetector.cpp
+++ b/src/BitmapPatternDetector.cpp
@@ -7,6 +7,8 @@
 #include "BitmapPatternDetector.hpp"
 #include "BitmapThumbnail.hpp"
 #include "PatternLayout.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 namespace vernier {
 

--- a/src/BitmapPatternLayout.cpp
+++ b/src/BitmapPatternLayout.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "BitmapPatternLayout.hpp"
+#include <opencv2/imgcodecs.hpp>
 
 namespace vernier {
 

--- a/src/BitmapThumbnail.cpp
+++ b/src/BitmapThumbnail.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "BitmapThumbnail.hpp"
+#include <opencv2/highgui/highgui.hpp>
 //#ifndef WIN32 
 //#include "opencv2/img_hash.hpp"
 //#endif

--- a/src/HPCodePatternDetector.cpp
+++ b/src/HPCodePatternDetector.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "HPCodePatternDetector.hpp"
+#include <opencv2/highgui/highgui.hpp>
 
 namespace vernier {
 

--- a/src/MegarenaPatternDetector.cpp
+++ b/src/MegarenaPatternDetector.cpp
@@ -6,6 +6,7 @@
 
 #include "MegarenaPatternDetector.hpp"
 #include "MegarenaBitSequence.hpp"
+#include <opencv2/highgui/highgui.hpp>
 
 namespace vernier {
 

--- a/src/MegarenaPatternLayout.cpp
+++ b/src/MegarenaPatternLayout.cpp
@@ -6,6 +6,7 @@
 
 #include "MegarenaPatternLayout.hpp"
 #include "MegarenaBitSequence.hpp"
+#include <opencv2/imgcodecs.hpp>
 
 namespace vernier {
 

--- a/src/MegarenaThumbnail.cpp
+++ b/src/MegarenaThumbnail.cpp
@@ -6,6 +6,7 @@
 
 #include "MegarenaThumbnail.hpp"
 #include <iomanip>
+#include <opencv2/highgui/highgui.hpp>
 
 namespace vernier {
 

--- a/src/PatternPhase.cpp
+++ b/src/PatternPhase.cpp
@@ -5,6 +5,8 @@
  */
 
 #include "PatternPhase.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 namespace vernier {
 

--- a/src/PeriodicPatternDetector.cpp
+++ b/src/PeriodicPatternDetector.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "PeriodicPatternDetector.hpp"
+#include <opencv2/highgui/highgui.hpp>
 
 namespace vernier {
 

--- a/src/PeriodicPatternLayout.cpp
+++ b/src/PeriodicPatternLayout.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "PeriodicPatternLayout.hpp"
+#include <opencv2/imgcodecs.hpp>
 
 namespace vernier {
 

--- a/src/Pose.cpp
+++ b/src/Pose.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Pose.hpp"
+#include <opencv2/calib3d.hpp>
 
 namespace vernier {
 

--- a/src/QRCodeDetector.cpp
+++ b/src/QRCodeDetector.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "QRCodeDetector.hpp"
+#include <opencv2/highgui/highgui.hpp>
 
 namespace vernier {
 

--- a/src/StampPatternDetector.cpp
+++ b/src/StampPatternDetector.cpp
@@ -6,6 +6,7 @@
 
 #include "StampPatternDetector.hpp"
 #include "Spatial.hpp"
+#include <opencv2/imgcodecs.hpp>
 
 namespace vernier {
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Utils.hpp"
+#include <opencv2/highgui/highgui.hpp>
 
 namespace vernier {
 

--- a/test/TestFourierTransform.cpp
+++ b/test/TestFourierTransform.cpp
@@ -8,6 +8,7 @@
 #include "UnitTest.hpp"
 #include <complex>
 #include <random>
+#include <opencv2/highgui/highgui.hpp>
 
 using namespace vernier;
 using namespace std;

--- a/test/TestMegarenaPatternDetector.cpp
+++ b/test/TestMegarenaPatternDetector.cpp
@@ -6,6 +6,8 @@
 
 #include "Vernier.hpp"
 #include "UnitTest.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace cv;

--- a/test/TestPatternPhase.cpp
+++ b/test/TestPatternPhase.cpp
@@ -9,6 +9,8 @@
 #include "PeriodicPatternLayout.hpp"
 #include "eigen-matio/MatioFile.hpp"
 #include <random>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace std;

--- a/test/TestPeriodicPatternDetector.cpp
+++ b/test/TestPeriodicPatternDetector.cpp
@@ -6,6 +6,7 @@
 
 #include "Vernier.hpp"
 #include "UnitTest.hpp"
+#include <opencv2/highgui/highgui.hpp>
 
 using namespace vernier;
 using namespace cv;

--- a/test/TestQRCodeDetector.cpp
+++ b/test/TestQRCodeDetector.cpp
@@ -6,6 +6,8 @@
 
 #include "QRCodeDetector.hpp"
 #include "UnitTest.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 //#include <opencv2/objdetect/graphical_code_detector.hpp>
 
 using namespace vernier;

--- a/test/TestQRFiducialDetector.cpp
+++ b/test/TestQRFiducialDetector.cpp
@@ -6,6 +6,8 @@
 
 #include "QRFiducialDetector.hpp"
 #include "UnitTest.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace std;

--- a/test/TestSpatial.cpp
+++ b/test/TestSpatial.cpp
@@ -8,6 +8,7 @@
 #include "Spectrum.hpp"
 #include "eigen-matio/MatioFile.hpp"
 #include "UnitTest.hpp"
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace std;

--- a/test/TestSquareDetector.cpp
+++ b/test/TestSquareDetector.cpp
@@ -6,6 +6,8 @@
 
 #include "SquareDetector.hpp"
 #include "UnitTest.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace std;

--- a/test/testBitmapPatternDetector.cpp
+++ b/test/testBitmapPatternDetector.cpp
@@ -9,6 +9,8 @@
 #include "Layout.hpp"
 #include "UnitTest.hpp"
 #include <iomanip>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace std;

--- a/test/testHPCodePatternDetector.cpp
+++ b/test/testHPCodePatternDetector.cpp
@@ -8,6 +8,8 @@
 #include "HPCodePatternLayout.hpp"
 #include "UnitTest.hpp"
 #include <iomanip>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace std;

--- a/test/testPatternRendering.cpp
+++ b/test/testPatternRendering.cpp
@@ -7,6 +7,7 @@
 #include "Layout.hpp"
 #include "UnitTest.hpp"
 #include <fstream>
+#include <opencv2/highgui/highgui.hpp>
 
 using namespace vernier;
 using namespace std;

--- a/test/testStampPatternDetector.cpp
+++ b/test/testStampPatternDetector.cpp
@@ -9,6 +9,8 @@
 #include "UnitTest.hpp"
 #include <iomanip>
 #include <opencv4/opencv2/core/mat.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace vernier;
 using namespace std;


### PR DESCRIPTION
Stop pulling OpenCV `highgui` and `calib3d` in through `Common.hpp`,
so every file (including the pure pose maths) no longer compiles against the GUI.
The files that actually use `imshow`/`imread`/`Rodrigues` now include what they need directly.