### PR TITLE
Library output cleanup

### DIFF
--- a/src/HPCodePatternDetector.cpp
+++ b/src/HPCodePatternDetector.cpp
@@ -40,10 +40,10 @@ namespace vernier {
             
             int diameter = (int) (2 * code.getRadius());
             if (snapshot.cols() < diameter) {
-                std::cout << "The HPCode is too large for pose estimation: increase the snapshot size over " << diameter << " pixels." << std::endl;
+                std::cerr << "The HPCode is too large for pose estimation: increase the snapshot size over " << diameter << " pixels." << std::endl;
             }
             if (2 * diameter < numberHalfPeriods) {
-                std::cout << "The HPCode is too tiny for pose estimation: increase the picture quality size." << std::endl;
+                std::cerr << "The HPCode is too tiny for pose estimation: increase the picture quality size." << std::endl;
             }
 
             int centerX = (int) code.center.x;
@@ -112,11 +112,9 @@ namespace vernier {
 
         // Analysing the line
         int dotCount = 7 + (int) std::round((cv::norm(code.top - code.right) / dotSize));
-        //std::cout << "dotCount : " << 7 + (double)(cv::norm(code.top - code.right) / dotSize) << std::endl;
         cv::Mat dataLine(1, dotCount - 14, CV_8U);
         cv::resize(rasterLine, dataLine, dataLine.size(), 0, 0, cv::INTER_AREA);
         cv::threshold(dataLine, dataLine, 0, 255, cv::THRESH_BINARY | cv::THRESH_OTSU);
-        //std::cout << "data line : " << dataLine << std::endl;
         int zeroCount = 0;
         for (int col = 0; col < dataLine.cols; col += 2) {
             if (dataLine.at<unsigned char>(0, col) == 0) {

--- a/src/MegarenaPatternDetector.cpp
+++ b/src/MegarenaPatternDetector.cpp
@@ -108,25 +108,21 @@ namespace vernier {
 
         if (periodShift1 >= 0 && periodShift2 >= 0) {
             // no change	
-            //std::cout<<"code1>0 && code2>0"<<std::endl;
         } else if (periodShift1 < 0 && periodShift2 >= 0) {
             std::swap(periodShift1, periodShift2);
             std::swap(plane1, plane2);
             plane2.flip();
-            //std::cout<<"code1<0 && code2>0"<<std::endl;
             thumbnail.rotate270();
             patternPhase.rotate270();
         } else if (periodShift1 >= 0 && periodShift2 < 0) {
             std::swap(periodShift1, periodShift2);
             std::swap(plane1, plane2);
             plane1.flip();
-            //std::cout<<"code1>0 && code2<0"<<std::endl;
             thumbnail.rotate90();
             patternPhase.rotate90();
         } else {
             plane1.flip();
             plane2.flip();
-            //std::cout<<"code1<0 && code2<0"<<std::endl;
             thumbnail.rotate180();
             patternPhase.rotate180();
         }

--- a/src/MegarenaThumbnail.cpp
+++ b/src/MegarenaThumbnail.cpp
@@ -164,7 +164,6 @@ namespace vernier {
 
                 contrastVec1(contrastVec1.rows() - 1) = (codeIntensity1(index1, 2) - codeIntensity1(index1, 1));
 
-                //std::cout << (codeIntensity1(index1, 2) - codeIntensity1(index1, 1)) / 256.0 << std::endl;
 
                 if (abs(meanCodingDots1(index1) - meanBackRefDots1(index1)) < abs(meanWhiteRefDots1(index1) - meanCodingDots1(index1))) {
                     sequence1(index1) = -1;
@@ -172,7 +171,6 @@ namespace vernier {
                     sequence1(index1) = 1;
                 }
             }
-            //std::cout << "Index1 " << index1 << std::endl;
         }
 
         // sequence 2
@@ -214,7 +212,6 @@ namespace vernier {
                 contrastVec2.conservativeResize(contrastVec2.rows() + 1, contrastVec2.cols());
                 contrastVec2(contrastVec2.rows() - 1) = (codeIntensity2(index2, 2) - codeIntensity2(index2, 1));
 
-                //std::cout << (codeIntensity2(index2, 2) - codeIntensity2(index2, 1)) / 256.0 << std::endl;
 
                 if (abs(meanCodingDots2(index2) - meanBackRefDots2(index2)) < abs(meanWhiteRefDots2(index2) - meanCodingDots2(index2))) {
                     sequence2(index2) = -1;
@@ -661,7 +658,6 @@ namespace vernier {
                     codingLevelSecurity2.conservativeResize(codingLevelSecurity2.rows() + 1, codingLevelSecurity2.cols());
 
                     double contrastLevel = (codeIntensity1(i, 2) - codeIntensity1(i, 1));
-                    //std::cout << codeIntensity1(i, 2) << "     " << codeIntensity1(i, 1) << std::endl;
 
                     codingLevelSecurity2(codingLevelSecurity2.rows() - 1, 0) = contrastLevel;
                     codingLevelSecurity2(codingLevelSecurity2.rows() - 1, 1) = codingLevel2;
@@ -675,7 +671,6 @@ namespace vernier {
                     codingLevelSecurity2(codingLevelSecurity2.rows() - 1, 9) = i;
                     codingLevelSecurity2(codingLevelSecurity2.rows() - 1, 10) = sequence1.rows();
 
-                    //std::cout << numberWhiteRefDots2(i - 2) << std::endl;
                 }
             }
         }

--- a/src/PatternLayout.cpp
+++ b/src/PatternLayout.cpp
@@ -173,13 +173,14 @@ namespace vernier {
         file << "</desc>" << std::endl;
         std::vector<Rectangle> rectangleList;
         toRectangleVector(rectangleList);
+        size_t progressStep = std::max<size_t>(1, rectangleList.size() / 100);
         for (int i = 0; i < rectangleList.size(); i++) {
             file << "<rect x=\"" << rectangleList[i].x + leftMargin << "\" ";
             file << "y=\"" << rectangleList[i].y + topMargin << "\" ";
             file << "width=\"" << rectangleList[i].width << "\" ";
             file << "height=\"" << rectangleList[i].height << "\" ";
             file << "fill=\"black\" />" << std::endl;
-            if (i % (rectangleList.size() / 100) == 0) {
+            if (i % progressStep == 0) {
                 std::cout << " \r Writing " << filename << " : " << 100 * i / rectangleList.size() << " %            " << std::flush;
             }
         }
@@ -206,11 +207,12 @@ namespace vernier {
         file << "int main() {" << std::endl;
         std::vector<Rectangle> rectangleList;
         toRectangleVector(rectangleList);
+        size_t progressStep = std::max<size_t>(1, rectangleList.size() / 100);
         for (int i = 0; i < rectangleList.size(); i++) {
             file << "layout->drawing->point(" << 1000 * (rectangleList[i].x + leftMargin) << "," << -1000 * (rectangleList[i].y + topMargin) << ");" << std::endl;
             file << "layout->drawing->point(" << 1000 * (rectangleList[i].x + leftMargin + rectangleList[i].width) << "," << -1000 * (rectangleList[i].y + topMargin + rectangleList[i].height) << ");" << std::endl;
             file << "layout->drawing->box();" << std::endl;
-            if (i % (rectangleList.size() / 100) == 0) {
+            if (i % progressStep == 0) {
                 std::cout << " \r Writing " << filename << " : " << 100 * i / rectangleList.size() << " %            " << std::flush;
             }
         }
@@ -231,10 +233,11 @@ namespace vernier {
 
         gdstk::Cell * cell = new gdstk::Cell();
         cell->init(name.c_str());
+        size_t progressStep = std::max<size_t>(1, rectangleList.size() / 100);
         for (int i = 0; i < rectangleList.size(); i++) {
             gdstk::Polygon * polygon = new gdstk::Polygon(gdstk::rectangle(gdstk::Vec2{rectangleList[i].x + leftMargin, -(rectangleList[i].y + topMargin)}, gdstk::Vec2{rectangleList[i].x + rectangleList[i].width + leftMargin, -(rectangleList[i].y + rectangleList[i].height + topMargin)}, gdstk::make_tag(1, 1)));
             cell->polygon_array.append(polygon);
-            if (i % (rectangleList.size() / 100) == 0) {
+            if (i % progressStep == 0) {
                 std::cout << " \r Building cell " << name << " : " << 100 * i / rectangleList.size() << " %            " << std::flush;
             }
         }

--- a/src/PatternLayout.cpp
+++ b/src/PatternLayout.cpp
@@ -181,12 +181,12 @@ namespace vernier {
             file << "height=\"" << rectangleList[i].height << "\" ";
             file << "fill=\"black\" />" << std::endl;
             if (i % progressStep == 0) {
-                std::cout << " \r Writing " << filename << " : " << 100 * i / rectangleList.size() << " %            " << std::flush;
+                std::cerr << " \r Writing " << filename << " : " << 100 * i / rectangleList.size() << " %            " << std::flush;
             }
         }
         file << "</svg>" << std::endl;
         file.close();
-        std::cout << "\r Writing " << filename << " : completed            " << std::endl;
+        std::cerr << "\r Writing " << filename << " : completed            " << std::endl;
     }
 
     void PatternLayout::saveToLayoutEditorMacro(std::string filename) {
@@ -213,12 +213,12 @@ namespace vernier {
             file << "layout->drawing->point(" << 1000 * (rectangleList[i].x + leftMargin + rectangleList[i].width) << "," << -1000 * (rectangleList[i].y + topMargin + rectangleList[i].height) << ");" << std::endl;
             file << "layout->drawing->box();" << std::endl;
             if (i % progressStep == 0) {
-                std::cout << " \r Writing " << filename << " : " << 100 * i / rectangleList.size() << " %            " << std::flush;
+                std::cerr << " \r Writing " << filename << " : " << 100 * i / rectangleList.size() << " %            " << std::flush;
             }
         }
         file << "}" << std::endl;
         file.close();
-        std::cout << "\r Writing " << filename << " : completed            " << std::endl;
+        std::cerr << "\r Writing " << filename << " : completed            " << std::endl;
     }
 
 #ifndef WIN32
@@ -238,7 +238,7 @@ namespace vernier {
             gdstk::Polygon * polygon = new gdstk::Polygon(gdstk::rectangle(gdstk::Vec2{rectangleList[i].x + leftMargin, -(rectangleList[i].y + topMargin)}, gdstk::Vec2{rectangleList[i].x + rectangleList[i].width + leftMargin, -(rectangleList[i].y + rectangleList[i].height + topMargin)}, gdstk::make_tag(1, 1)));
             cell->polygon_array.append(polygon);
             if (i % progressStep == 0) {
-                std::cout << " \r Building cell " << name << " : " << 100 * i / rectangleList.size() << " %            " << std::flush;
+                std::cerr << " \r Building cell " << name << " : " << 100 * i / rectangleList.size() << " %            " << std::flush;
             }
         }
 
@@ -264,7 +264,7 @@ namespace vernier {
         gdstk::Cell * cell = convertToGDSCell();
         lib.cell_array.append(cell);
 
-        std::cout << "\r Writing " << filename << " : starting...            " << std::flush;
+        std::cerr << "\r Writing " << filename << " : starting...            " << std::flush;
         lib.write_gds(filename.c_str(), 0, NULL);
         //lib.write_oas(filename.c_str(), 0, 6, OASIS_CONFIG_DETECT_ALL);
         //cell->write_svg(filename.c_str(), 10, 6, NULL, NULL, "#222222", 5, true, NULL);
@@ -272,7 +272,7 @@ namespace vernier {
         lib.clear();
         cell->clear(); // possible memory leak: are polygons really deleted?
         delete cell;
-        std::cout << "\r Writing " << filename << " : completed            " << std::endl;
+        std::cerr << "\r Writing " << filename << " : completed            " << std::endl;
     }
 
     void PatternLayout::saveToOASIS(std::string filename) {
@@ -285,7 +285,7 @@ namespace vernier {
         gdstk::Cell * cell = convertToGDSCell();
         lib.cell_array.append(cell);
 
-        std::cout << "\r Writing " << filename << " : starting...            " << std::flush;
+        std::cerr << "\r Writing " << filename << " : starting...            " << std::flush;
         //lib.write_gds(filename.c_str(), 0, NULL);
         lib.write_oas(filename.c_str(), 0, 6, OASIS_CONFIG_DETECT_ALL);
         //cell->write_svg(filename.c_str(), 10, 6, NULL, NULL, "#222222", 5, true, NULL);
@@ -293,7 +293,7 @@ namespace vernier {
         lib.clear();
         cell->clear(); // possible memory leak: are polygons really deleted?
         delete cell;
-        std::cout << "\r Writing " << filename << " : completed            " << std::endl;
+        std::cerr << "\r Writing " << filename << " : completed            " << std::endl;
     }
 #endif
 

--- a/src/PatternPhase.cpp
+++ b/src/PatternPhase.cpp
@@ -147,7 +147,6 @@ namespace vernier {
         double mean = cv::mean(sobelX)[0];
         betaSign = (mean > 0) - (mean < 0);
 
-        //std::cout << "mean first direction SOBEL : " << mean << std::endl;
         //cv::normalize(phaseDerived, phaseDerived, 1, 0, cv::NORM_MINMAX);
         //cv::imshow("phase 1 derived", phaseDerived);
 
@@ -185,7 +184,6 @@ namespace vernier {
         cv::Sobel(phaseDerived, sobelY, CV_64F, 0, 1);
         double mean2 = cv::mean(sobelY)[0];
 
-        //std::cout << "mean second direction SOBEL : " << mean2 << std::endl;
         gammaSign = (mean2 > 0) - (mean2 < 0);
     }
 

--- a/src/Spectrum.cpp
+++ b/src/Spectrum.cpp
@@ -48,7 +48,6 @@ namespace vernier {
             }
         }
 
-        //std::cout<< "Peak value (half plane method) : " << mainPeak1.z() <<std::endl;
         if (mainPeak1.z() > 1e-5) { // MAGIC NUMBER
             int PEAK_MASK = 8;
             source.block(mainPeak1.y() - PEAK_MASK, mainPeak1.x() - PEAK_MASK, 2 * PEAK_MASK, 2 * PEAK_MASK) = 0;
@@ -81,10 +80,7 @@ namespace vernier {
         //        }
 
 
-        //        std::cout<<"Image size"<<source.rows()<<"x"<<source.cols()<<std::endl;
         //        
-        //        std::cout<<"Peak 1"<<mainPeak1<<std::endl;
-        //        std::cout<<"Peak 2"<<mainPeak2<<std::endl;
         //        
     }
 

--- a/src/StampPatternDetector.cpp
+++ b/src/StampPatternDetector.cpp
@@ -53,11 +53,9 @@ namespace vernier {
             Square square = detector.squares[i];
             int diameter = (int) (2 * square.getRadius());
             if (snapshot.cols() < diameter) {
-                std::cout << "The stamp is too large for pose estimation: increase the snapshot size over " << diameter << " pixels." << std::endl;
+                std::cerr << "The stamp is too large for pose estimation: increase the snapshot size over " << diameter << " pixels." << std::endl;
             }
-            if (diameter < 2 * bitmapThumbnail.size()) {
-                //std::cout << "The stamp is too tiny for pose estimation: increase the picture quality size." << std::endl;
-            } else {
+            if (diameter >= 2 * bitmapThumbnail.size()) {
 
                 int centerX = (int) square.getCenter().x;
                 int centerY = (int) square.getCenter().y;


### PR DESCRIPTION
Send library messages to stderr and remove the dead commented-out `std::cout` debug lines.

Stacked on #10 because both touch the same export progress-print line.